### PR TITLE
rely on R's subsetting

### DIFF
--- a/R/colors.R
+++ b/R/colors.R
@@ -15,7 +15,7 @@
 #' pal <- wes.palette(name = "Zissou", type = "continuous")
 #' image(volcano, col = pal(21))
 
-wes.palette <- function(n, name, type = FALSE) {
+wes.palette <- function(name, type = FALSE) {
 	
 GrandBudapest <- c("#F1BB7B", "#FD6467", "#5B1A18", "#D67236")
 Moonrise1 <- c("#F3DF6C", "#CEAB07", "#D5D5D3", "#24281A")
@@ -43,7 +43,7 @@ if(!type) {
 if(n > namelist[which(namelist$movies == name), 2])
 	stop("Number of requested colors greater than what palette can offer")
 
-get(name)[1:n]
+get(name)
 } 
 }
 


### PR DESCRIPTION
Hey, I think you should do it this way. Right now I have to
- [a] look up first how many colours are in each palette (extra step), and
- [b] I cannot take just eg colours `2:4`.

You might say -- ok, do `wes.palette(5, 'Darjeeling2')[2:5]`. Fine. But in this case why have the call to `n` in the first place?
