### PR TITLE
README.Rmd: cavalcanti1 should be cavalcanti

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -127,7 +127,7 @@ wes_palette("Moonrise3")
 ### Castello Cavalcanti (2013)
 
 ```{r, castello}
-wes_palette("Cavalcanti1")
+wes_palette("Cavalcanti")
 ```
 
 ### The Grand Budapest Hotel (2014)


### PR DESCRIPTION
Fix palette name in the Rmd; md file will need to be regenerated.