### PR TITLE
Add note for path to hex code

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ names(wes_palettes)
 
 ## Palettes
 
+NOTE: hexadecimal color codes are available in `./R/colors.R`.
+
 ### Bottle Rocket (1996)
 
 ``` r

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ names(wes_palettes)
 
 ## Palettes
 
-NOTE: hexadecimal color codes are available in `./R/colors.R`.
+NOTE: hexadecimal color codes are available in [./R/colors.R](./R/colors.R).
 
 ### Bottle Rocket (1996)
 


### PR DESCRIPTION
 First - amazing. I don't use R but I do plenty of plotting with other tools and it's my own little easter egg to use these color palettes.

This pull request adds a note that the hex color codes are available in the repo. I first created the hex codes with the digital color picker on mac, and then subsequently found the hex codes in `colors.R`. A simple note *may* have save me some headache, so I thought it might be useful to others, as well.

Free free to close if you don't want it, I won't be offended. Thanks again!