### PR TITLE
fix error in wes_palette documentation

### DIFF
--- a/R/colors.R
+++ b/R/colors.R
@@ -45,7 +45,7 @@ wes_palettes <- list(
 #'   \code{Darjeeling2},  \code{Chevalier1} , \code{FantasticFox1} ,
 #'   \code{Moonrise1}, \code{Moonrise2}, \code{Moonrise3}, \code{Cavalcanti1},
 #'   \code{GrandBudapest1}, \code{GrandBudapest2}, \code{IsleofDogs1}, \code{IsleofDogs2},
-#'   \code{FrenchDispatch}, \code{AsteroidCity2}, \code{AsteroidCity2}, \code{AsteroidCity3}
+#'   \code{FrenchDispatch}, \code{AsteroidCity1}, \code{AsteroidCity2}, \code{AsteroidCity3}
 #' @param type Either "continuous" or "discrete". Use continuous if you want
 #'   to automatically interpolate between colours.
 #'   @importFrom graphics rgb rect par image text

--- a/man/wes_palette.Rd
+++ b/man/wes_palette.Rd
@@ -13,7 +13,7 @@ wes_palette(name, n, type = c("discrete", "continuous"))
 \code{Darjeeling2},  \code{Chevalier1} , \code{FantasticFox1} ,
 \code{Moonrise1}, \code{Moonrise2}, \code{Moonrise3}, \code{Cavalcanti1},
 \code{GrandBudapest1}, \code{GrandBudapest2}, \code{IsleofDogs1}, \code{IsleofDogs2},
-\code{FrenchDispatch}, \code{AsteroidCity2}, \code{AsteroidCity2}, \code{AsteroidCity3}}
+\code{FrenchDispatch}, \code{AsteroidCity1}, \code{AsteroidCity2}, \code{AsteroidCity3}}
 
 \item{n}{Number of colors desired. Unfortunately most palettes now only
 have 4 or 5 colors. But hopefully we'll add more palettes soon. All color


### PR DESCRIPTION
The choice 'AsteroidCity2' is repeated twice in the documentation while 'AsteroidCity1' does not exist, so the first 'AsteroidCity2' was changed to the missing choice.